### PR TITLE
Add TLS by default, remove unused trigger

### DIFF
--- a/BaseProject/Assets/PusherManager.cs
+++ b/BaseProject/Assets/PusherManager.cs
@@ -35,7 +35,8 @@ public class PusherManager : MonoBehaviour
         {
             _pusher = new Pusher(APP_KEY, new PusherOptions()
             {
-                Cluster = APP_CLUSTER
+                Cluster = APP_CLUSTER,
+                Encrypted = true
             });
 
             _pusher.Error += OnPusherOnError;
@@ -73,11 +74,6 @@ public class PusherManager : MonoBehaviour
     private void OnChannelOnSubscribed(object s)
     {
         Debug.Log("Subscribed");
-    }
-
-    public void Message(string message)
-    {
-        _channel?.Trigger("time has occured", message);
     }
 
     async Task OnApplicationQuit()


### PR DESCRIPTION
This PR:
- adds to the `BaseProject` the TLS Encryption by default
- removes unused `Trigger` in `PusherManager.cs`