### PR TITLE
Update Makefile to not tag commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 build-release:
 	git subtree split --prefix=BaseProject/Assets/PusherWebsocketUnity --branch upm
-	git tag $(VERSION) upm
 
 push-release:
-	git push origin upm --tags
+	git push origin upm


### PR DESCRIPTION
The tagging will be generated by the GitHub Release.